### PR TITLE
05 コメント機能を実装した

### DIFF
--- a/app/controllers/posts/comments_controller.rb
+++ b/app/controllers/posts/comments_controller.rb
@@ -1,0 +1,32 @@
+class Posts::CommentsController < ApplicationController
+  before_action :require_login
+
+  def create
+    @comment = current_user.comments.build(comment_params)
+    @comment.save
+  end
+
+  def edit
+    @comment = current_user.comments.find(params[:id])
+  end
+
+  def update
+    @comment = current_user.comments.find(params[:id])
+    @comment.update(comment_params)
+  end
+
+  def show
+    @comment = current_user.comments.find(params[:id])
+  end
+
+  def destroy
+    @comment = current_user.comments.find(params[:id])
+    @comment.destroy!
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:body).merge(post_id: params[:post_id])
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -32,6 +32,8 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
+    @comments = @post.comments
+    @comment = Comment.new
   end
 
   def destroy

--- a/app/javascript/custom-mdb-ui-kit.js
+++ b/app/javascript/custom-mdb-ui-kit.js
@@ -12,3 +12,14 @@ const mdbInputUpdate = () => {
 document.addEventListener('turbo:render', () => {
     mdbInputUpdate();
 });
+// コメントを新規作成した際にテキストフィールドのアウトラインが表示されなくなる不具合への対応
+document.addEventListener('turbo:frame-render', () => {
+    mdbInputUpdate();
+});
+
+document.addEventListener('turbo:submit-end', () => {
+    setTimeout(
+        mdbInputUpdate,
+        100
+    )
+});

--- a/app/views/posts/comments/_comment.html.erb
+++ b/app/views/posts/comments/_comment.html.erb
@@ -1,0 +1,31 @@
+<%= turbo_frame_tag dom_id comment do %>
+  <div class="d-flex gap-3">
+    <%= image_tag 'http://placehold.jp/40x40.png',
+                  class: 'rounded-circle',
+                  width: 40,
+                  height: 40 %>
+    <div class="w-100">
+      <span class="font-weight-bold"><%= comment.user.username %></span>
+      <%= simple_format(comment.body) %>
+      <p class="card-text text-end">
+        <small class="text-muted"><%= l comment.created_at, format: :long %></small>
+      </p>
+      <% if current_user && current_user.owner?(comment) %>
+        <div class="text-end">
+          <span class="me-2">
+            <%= link_to edit_post_comment_path(comment.post, comment), class: 'btn btn-floating btn-success btn-sm btn-edit' do %>
+              <i class="far fa-edit"></i>
+            <% end %>
+          </span>
+          <span>
+            <%= link_to post_comment_path(comment.post, comment), class: 'btn btn-floating btn-danger btn-sm btn-delete', data: { turbo_method: :delete, turbo_confirm: '削除します' } do %>
+              <i class="far fa-trash-alt"></i>
+            <% end %>
+          </span>
+        </div>
+        <!-- /.text-end -->
+      <% end %>
+    </div>
+  </div>
+  <hr>
+<% end %>

--- a/app/views/posts/comments/_form.html.erb
+++ b/app/views/posts/comments/_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_with(model: [post, comment], id: dom_id(comment, 'form'), class: 'row gy-2 gx-3 align-items-center') do |f| %>
+  <%= render 'shared/error_messages', object: comment %>
+
+  <div class="col-9">
+    <div class="form-outline">
+      <%= f.text_area :body, class: 'form-control' %>
+      <%= f.label :body, class: 'form-label' %>
+    </div>
+    <!-- /.form-outline -->
+  </div>
+  <!-- /.col-9 -->
+  <div class="col-3">
+    <%= f.submit class: 'btn btn-primary btn-sm' %>
+  </div>
+  <!-- /.col-3 -->
+<% end %>

--- a/app/views/posts/comments/create.turbo_stream.erb
+++ b/app/views/posts/comments/create.turbo_stream.erb
@@ -1,0 +1,9 @@
+<% if @comment.valid? %>
+  <%= turbo_stream.append "comments", @comment %>
+<% end %>
+
+<%= turbo_stream.replace(
+      'form_comment',
+      partial: 'form',
+      locals: { post: @comment.post, comment: @comment.valid? ? Comment.new : @comment }
+    ) %>

--- a/app/views/posts/comments/destroy.turbo_stream.erb
+++ b/app/views/posts/comments/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove(@comment) %>

--- a/app/views/posts/comments/edit.html.erb
+++ b/app/views/posts/comments/edit.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag dom_id @comment do %>
+  <%= render 'form', post: @comment.post, comment: @comment %>
+  <div class="mt-3">
+    <%= link_to 'キャンセル', [@comment.post, @comment], class: 'btn btn-link btn-sm' %>
+  </div>
+  <hr>
+<% end %>

--- a/app/views/posts/comments/show.html.erb
+++ b/app/views/posts/comments/show.html.erb
@@ -1,0 +1,1 @@
+<%= render @comment %>

--- a/app/views/posts/comments/update.turbo_stream.erb
+++ b/app/views/posts/comments/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<% if @comment.valid? %>
+  <%= turbo_stream.replace(@comment) %>
+<% else %>
+  <%= turbo_stream.replace(
+        dom_id(@comment, 'form'),
+        partial: 'form',
+        locals: { post: @comment.post, comment: @comment }
+      ) %>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,7 +4,8 @@
       <%= render 'carousel_images', post: @post %>
     </div>
     <!-- /.col-8 -->
-    <div class="col-4">
+<!--    <div class="col-4 d-flex flex-column justify-content-between">-->
+    <div class="col-4 d-flex flex-column">
       <div class="card-header">
         <div class="d-flex justify-content-between align-items-center">
           <div class="d-flex align-items-center gap-3">
@@ -44,66 +45,33 @@
         <!-- /.d-flex justify-content-between align-items-center -->
       </div>
       <!-- /.card-header -->
-      <div class="card-body">
+      <div class="card-body" style="max-height: 400px; overflow-y: scroll">
         <div class="d-flex gap-3">
           <%= image_tag 'http://placehold.jp/40x40.png',
                         class: 'rounded-circle',
                         width: 40,
                         height: 40 %>
-          <div>
+          <div class="w-100">
             <span class="font-weight-bold"><%= @post.user.username %></span>
             <%= simple_format(@post.body) %>
-            <p class="card-text">
+            <p class="card-text text-end">
               <small class="text-muted"><%= l @post.created_at, format: :long %></small>
             </p>
           </div>
         </div>
         <!-- /.d-flex gap-3 -->
-        <div class="d-flex gap-3">
-          <%= image_tag 'http://placehold.jp/40x40.png',
-                        class: 'rounded-circle',
-                        width: 40,
-                        height: 40 %>
-          <div>
-            <span class="font-weight-bold">ダミー太郎</span>
-            <p>ダミーテキストダミーテキスト</p>
-            <p class="card-text">
-              <small class="text-muted">2022/04/04 00:16</small>
-            </p>
-          </div>
+        <hr>
+
+        <div id="comments">
+          <%= render partial: 'posts/comments/comment', collection: @comments %>
         </div>
-        <!-- /.d-flex gap-3 -->
-        <div class="d-flex gap-3">
-          <%= image_tag 'http://placehold.jp/40x40.png',
-                        class: 'rounded-circle',
-                        width: 40,
-                        height: 40 %>
-          <div>
-            <span class="font-weight-bold">ダミー太郎</span>
-            <p>ダミーテキストダミーテキスト</p>
-            <p class="card-text">
-              <small class="text-muted">2022/04/04 00:16</small>
-            </p>
-          </div>
-        </div>
-        <!-- /.d-flex gap-3 -->
-        <div class="card-footer">
-          <form class="row gy-2 gx-3 align-items-center">
-            <div class="col-9">
-              <div class="form-outline">
-                <input type="text" id="form11Example1" class="form-control" autocomplete="off">
-                <label class="form-label" for="form11Example1">Label</label>
-              </div>
-            </div>
-            <div class="col-3">
-              <button type="submit" class="btn btn-primary">Submit</button>
-            </div>
-          </form>
-        </div>
-        <!-- /.card-footer -->
+        <!-- /#comments -->
       </div>
       <!-- /.card-body -->
-
+      <div class="card-footer">
+        <%= render 'posts/comments/form', post: @post, comment: @comment %>
+      </div>
+      <!-- /.card-footer -->
     </div>
     <!-- /.col-4 -->
   </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: ユーザー
       post: 投稿
+      comment: コメント
     attributes:
       user:
         email: メールアドレス
@@ -12,6 +13,8 @@ ja:
       post:
         body: 本文
         images: 画像
+      comment:
+        body: コメント
 
   attributes:
     created_at: 作成日時

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
   post '/login', to: 'user_sessions#create'
   delete '/logout', to: 'user_sessions#destroy'
 
-  resources :posts
+  resources :posts do
+    resources :comments, module: :posts
+  end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -21,8 +21,8 @@
 #
 FactoryBot.define do
   factory :comment do
-    body { "MyText" }
-    user { nil }
-    post { nil }
+    body { Faker::Lorem.sentence }
+    user
+    post
   end
 end

--- a/spec/requests/posts/comments_spec.rb
+++ b/spec/requests/posts/comments_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Posts::Comments", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'コメント', type: :system do
+  let!(:user) { create(:user) }
+  let!(:post) { create(:post) }
+  before do
+    login_as(user)
+  end
+
+  describe '作成' do
+    it 'コメントが作成できること' do
+      visit post_path(post)
+      within '#form_comment' do
+        fill_in 'コメント', with: 'コメントです'
+        click_on '登録する'
+      end
+      expect(page).to have_content 'コメントです'
+    end
+  end
+
+  describe '更新' do
+    let!(:comment) { create(:comment, post: post, user: user) }
+    it 'コメントが更新できること' do
+      visit post_path(post)
+      within "#comment_#{comment.id}" do
+        find('.btn-edit').click
+      end
+      within "#form_comment_#{comment.id}" do
+        fill_in 'コメント', with: '更新コメントです'
+        click_on '更新する'
+      end
+      expect(page).to have_content '更新コメントです'
+    end
+  end
+
+  describe '削除' do
+    let!(:comment) { create(:comment, post: post, user: user) }
+    it 'コメントが削除できること' do
+      visit post_path(post)
+      within "#comment_#{comment.id}" do
+        accept_confirm { find('.btn-delete').click }
+      end
+      expect(page).not_to have_content comment.body
+    end
+  end
+end


### PR DESCRIPTION
## 概要

投稿にコメントができる機能を実装しました。

[![Image from Gyazo](https://i.gyazo.com/f655c475a7ee48f527334eb6edf7e7f8.gif)](https://gyazo.com/f655c475a7ee48f527334eb6edf7e7f8)

`turbo`の機能を使って非同期通信を実現しています。

### エンドポイント

| やりたいこと | HTTPメソッド | エンドポイント | コントローラ#アクション |
| ---- | ---- | ---- | ---- |
| 投稿をする | POST | posts/:post_id/comments | posts/comments#create |
| 編集フォームに切り替える | GET | posts/:post_id/comments/:id/edit | posts/comments#edit |
| 更新する | PATCH | posts/:post_id/comments/:id | posts/comments#update |
| 削除する | DELETE | posts/:post_id/comments/:id | posts/comments#destroy |
| 詳細に切り替える | GET | posts/:post_id/comments/:id | posts/comments#show |

## 確認方法

1. テーブルを作成したので `bin/rails db:migrate` を実行してください

コメントのCRUDが機能していることを確認してください。

## チェックリスト

- [x] テストを書いた
- [x] Lint のチェックをパスした

## コメント

このプルリクに入るべき[コミット](https://github.com/sarii0213/ig_clone/commit/c254f5bffd8ddb132bab5a4568500942153df4d3)が、１つ前のプルリクに入ってしまいました。

### 理由
これまで、`feature/*`ブランチで作業し、それを`develop`ブランチにマージしてプッシュし、`main`ブランチへのプルリクを作成していました。プルリクのマージをし忘れた状態で、次の作業の`feature/*`ブランチを`develop`ブランチにマージしてプッシュしてしまうと、どのコミットまでが前の`feature/*`ブランチでのものか分からなくなっていました。

### 改善点
gitでの作業の流れを以下のように変えようと思います。
新規作成した`feature/*`ブランチで作業後プッシュし、`develop`ブランチへプルリクを作成する。