### PR TITLE
通知の設定を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'sorcery'
 
 # 国際化
 gem 'rails-i18n'
+gem 'enum_help'
 
 gem 'activestorage-validator'
 

--- a/Gemfile
+++ b/Gemfile
@@ -52,8 +52,8 @@ gem 'image_processing', '~> 1.2'
 gem 'sorcery'
 
 # 国際化
-gem 'rails-i18n'
 gem 'enum_help'
+gem 'rails-i18n'
 
 gem 'activestorage-validator'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.8, >= 1.8.0)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erb_lint (0.1.3)
       activesupport
       better_html (~> 1.0.7)
@@ -391,6 +393,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   draper
+  enum_help
   erb_lint
   factory_bot_rails
   faker

--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -1,0 +1,20 @@
+class Mypage::NotificationSettingsController < Mypage::BaseController
+  def edit
+    @user = User.find(current_user.id)
+  end
+
+  def update
+    @user = User.find(current_user.id)
+    if @user.update(notification_settings_params)
+      redirect_to edit_mypage_notification_setting_path, success: '設定を更新しました'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def notification_settings_params
+    params.require(:user).permit(notification_timing_ids: [])
+  end
+end

--- a/app/controllers/posts/comments_controller.rb
+++ b/app/controllers/posts/comments_controller.rb
@@ -6,8 +6,11 @@ class Posts::CommentsController < ApplicationController
     # rubocop:disable Style/GuardClause
     if @comment.save
       create_notifications_about_comment_to_own_post(@comment)
-      UserMailer.with(user_from: current_user, user_to: @comment.post.user,
-                      comment: @comment).comment_post.deliver_later
+      UserMailer.with(
+        user_from: current_user,
+        user_to: @comment.post.user,
+        comment: @comment
+      ).comment_post.deliver_later if @comment.post.user.accepted_notification?(:on_commented)
     end
     # rubocop:enable Style/GuardClause
   end

--- a/app/controllers/posts/comments_controller.rb
+++ b/app/controllers/posts/comments_controller.rb
@@ -6,11 +6,11 @@ class Posts::CommentsController < ApplicationController
     # rubocop:disable Style/GuardClause
     if @comment.save
       create_notifications_about_comment_to_own_post(@comment)
-      UserMailer.with(
-        user_from: current_user,
-        user_to: @comment.post.user,
-        comment: @comment
-      ).comment_post.deliver_later if @comment.post.user.accepted_notification?(:on_commented)
+      if @comment.post.user.accepted_notification?(:on_commented)
+        UserMailer.with(
+          user_from: current_user, user_to: @comment.post.user, comment: @comment
+        ).comment_post.deliver_later
+      end
     end
     # rubocop:enable Style/GuardClause
   end

--- a/app/controllers/posts/likes_controller.rb
+++ b/app/controllers/posts/likes_controller.rb
@@ -6,7 +6,11 @@ class Posts::LikesController < ApplicationController
     # rubocop:disable Style/GuardClause
     if current_user.like(@post)
       create_notifications_about_like(@post)
-      UserMailer.with(user_from: current_user, user_to: @post.user, post: @post).like_post.deliver_later
+      UserMailer.with(
+        user_from: current_user,
+        user_to: @post.user,
+        post: @post
+      ).like_post.deliver_later if @post.user.accepted_notification?(:on_liked)
     end
     # rubocop:enable Style/GuardClause
   end

--- a/app/controllers/posts/likes_controller.rb
+++ b/app/controllers/posts/likes_controller.rb
@@ -6,11 +6,11 @@ class Posts::LikesController < ApplicationController
     # rubocop:disable Style/GuardClause
     if current_user.like(@post)
       create_notifications_about_like(@post)
-      UserMailer.with(
-        user_from: current_user,
-        user_to: @post.user,
-        post: @post
-      ).like_post.deliver_later if @post.user.accepted_notification?(:on_liked)
+      if @post.user.accepted_notification?(:on_liked)
+        UserMailer.with(
+          user_from: current_user, user_to: @post.user, post: @post
+        ).like_post.deliver_later
+      end
     end
     # rubocop:enable Style/GuardClause
   end

--- a/app/controllers/users/relationships_controller.rb
+++ b/app/controllers/users/relationships_controller.rb
@@ -6,10 +6,12 @@ class Users::RelationshipsController < ApplicationController
     # rubocop:disable Style/GuardClause
     if current_user.follow(@user)
       create_notifications_about_follow(@user)
-      UserMailer.with(
-        user_from: current_user,
-        user_to: @user
-      ).follow.deliver_later if @user.accepted_notification?(:on_followed)
+      if @user.accepted_notification?(:on_followed)
+        UserMailer.with(
+          user_from: current_user,
+          user_to: @user
+        ).follow.deliver_later
+      end
     end
     # rubocop:enable Style/GuardClause
   end

--- a/app/controllers/users/relationships_controller.rb
+++ b/app/controllers/users/relationships_controller.rb
@@ -6,7 +6,10 @@ class Users::RelationshipsController < ApplicationController
     # rubocop:disable Style/GuardClause
     if current_user.follow(@user)
       create_notifications_about_follow(@user)
-      UserMailer.with(user_from: current_user, user_to: @user).follow.deliver_later
+      UserMailer.with(
+        user_from: current_user,
+        user_to: @user
+      ).follow.deliver_later if @user.accepted_notification?(:on_followed)
     end
     # rubocop:enable Style/GuardClause
   end

--- a/app/models/notification_timing.rb
+++ b/app/models/notification_timing.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: notification_timings
+#
+#  id          :bigint           not null, primary key
+#  timing_type :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_notification_timings_on_timing_type  (timing_type) UNIQUE
+#
+class NotificationTiming < ApplicationRecord
+  enum timing_type: { on_commented: 1, on_liked: 2, on_followed: 3 }
+
+  validates :timing_type, presence: true
+  validates :timing_type, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,8 @@ class User < ApplicationRecord
   has_many :followers, through: :passive_relationships, source: :follower
   has_many :user_notifications, dependent: :destroy
   has_many :notifications, through: :user_notifications
+  has_many :user_notification_timings, dependent: :destroy
+  has_many :notification_timings, through: :user_notification_timings
   has_one_attached :avatar
 
   validates :username, uniqueness: true, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,4 +77,8 @@ class User < ApplicationRecord
   def feed
     Post.where(user_id: following_ids << id)
   end
+
+  def accepted_notification?(type)
+    notification_timings.find_by(timing_type: type).present?
+  end
 end

--- a/app/models/user_notification_timing.rb
+++ b/app/models/user_notification_timing.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: user_notification_timings
+#
+#  id                     :bigint           not null, primary key
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  notification_timing_id :bigint           not null
+#  user_id                :bigint           not null
+#
+# Indexes
+#
+#  idx_user_n_timings_on_user_id_and_n_timing_id              (user_id,notification_timing_id) UNIQUE
+#  index_user_notification_timings_on_notification_timing_id  (notification_timing_id)
+#  index_user_notification_timings_on_user_id                 (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (notification_timing_id => notification_timings.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class UserNotificationTiming < ApplicationRecord
+  belongs_to :user
+  belongs_to :notification_timing
+end

--- a/app/models/user_notification_timing.rb
+++ b/app/models/user_notification_timing.rb
@@ -22,4 +22,6 @@
 class UserNotificationTiming < ApplicationRecord
   belongs_to :user
   belongs_to :notification_timing
+
+  validates :user_id, uniqueness: { scope: :notification_timing_id }
 end

--- a/app/views/mypage/notification_settings/edit.html.erb
+++ b/app/views/mypage/notification_settings/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-12">
       <%= form_with model: @user, url: mypage_notification_setting_path do |f| %>
-        <%= f.collection_check_boxes :notification_timing_ids, NotificationTiming.all, :id, :timing_type do |b| %>
+        <%= f.collection_check_boxes :notification_timing_ids, NotificationTiming.all, :id, :timing_type_i18n do |b| %>
           <div class="mb-3">
             <%= b.label class: 'd-flex align-items-center gap-1' do %>
               <%= b.check_box %>

--- a/app/views/mypage/notification_settings/edit.html.erb
+++ b/app/views/mypage/notification_settings/edit.html.erb
@@ -1,0 +1,22 @@
+<div class="container">
+  <div class="row">
+    <div class="col-12">
+      <%= form_with model: @user, url: mypage_notification_setting_path do |f| %>
+        <%= f.collection_check_boxes :notification_timing_ids, NotificationTiming.all, :id, :timing_type do |b| %>
+          <div class="mb-3">
+            <%= b.label class: 'd-flex align-items-center gap-1' do %>
+              <%= b.check_box %>
+              <%= b.text %>
+            <% end %>
+          </div>
+        <% end %>
+        <div class="text-center">
+          <%= f.submit class: 'btn btn-primary' %>
+        </div>
+      <% end %>
+    </div>
+    <!-- /.col-12 -->
+  </div>
+  <!-- /.row -->
+</div>
+<!-- /.container -->

--- a/app/views/mypage/shared/_sidebar.html.erb
+++ b/app/views/mypage/shared/_sidebar.html.erb
@@ -12,5 +12,11 @@
         <span>通知一覧</span>
       <% end %>
     </li>
+    <li class="py-4 border-top">
+      <%= link_to edit_mypage_notification_setting_path, class: 'text-muted d-block' do %>
+        <i class="fas fa-cogs pe-2"></i>
+        <span>通知設定</span>
+      <% end %>
+    </li>
   </ul>
 </nav>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,7 +15,16 @@ ja:
         images: 画像
       comment:
         body: コメント
+      notification_timing:
+        timing_type: 通知タイミング
 
   attributes:
     created_at: 作成日時
     updated_at: 更新日時
+
+  enums:
+    notification_timing:
+      timing_type:
+        on_commented: 投稿にコメントがあった時
+        on_liked: 投稿にいいねがあった時
+        on_followed: フォローされた時

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     root to: 'accounts#edit'
     resource :account, only: %i[edit update]
     resources :notifications, only: %i[index]
+    resource :notification_setting, only: %i[edit update]
   end
 
   if Rails.env.development?

--- a/db/migrate/20220820225454_create_notification_timings.rb
+++ b/db/migrate/20220820225454_create_notification_timings.rb
@@ -1,0 +1,9 @@
+class CreateNotificationTimings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notification_timings do |t|
+      t.integer :timing_type, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220820235140_create_user_notification_timings.rb
+++ b/db/migrate/20220820235140_create_user_notification_timings.rb
@@ -1,0 +1,11 @@
+class CreateUserNotificationTimings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_notification_timings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :notification_timing, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :user_notification_timings, [:user_id, :notification_timing_id], unique: true, name: 'idx_user_n_timings_on_user_id_and_n_timing_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_20_225454) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_20_235140) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -91,6 +91,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_20_225454) do
     t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
+  create_table "user_notification_timings", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "notification_timing_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notification_timing_id"], name: "index_user_notification_timings_on_notification_timing_id"
+    t.index ["user_id", "notification_timing_id"], name: "idx_user_n_timings_on_user_id_and_n_timing_id", unique: true
+    t.index ["user_id"], name: "index_user_notification_timings_on_user_id"
+  end
+
   create_table "user_notifications", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "notification_id", null: false
     t.bigint "user_id", null: false
@@ -122,6 +132,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_20_225454) do
   add_foreign_key "posts", "users"
   add_foreign_key "relationships", "users", column: "followed_id"
   add_foreign_key "relationships", "users", column: "follower_id"
+  add_foreign_key "user_notification_timings", "notification_timings"
+  add_foreign_key "user_notification_timings", "users"
   add_foreign_key "user_notifications", "notifications"
   add_foreign_key "user_notifications", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_13_044313) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_20_225454) do
   create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -57,6 +57,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_13_044313) do
     t.index ["post_id", "user_id"], name: "index_likes_on_post_id_and_user_id", unique: true
     t.index ["post_id"], name: "index_likes_on_post_id"
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "notification_timings", charset: "utf8mb4", force: :cascade do |t|
+    t.integer "timing_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["timing_type"], name: "index_notification_timings_on_timing_type", unique: true
   end
 
   create_table "notifications", charset: "utf8mb4", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,4 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
-require './db/seeds/users'
-require './db/seeds/posts'
-require './db/seeds/notification_timings'
+require "./db/seeds/environment/#{Rails.env.downcase}.rb"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,4 @@
 #   Character.create(name: "Luke", movie: movies.first)
 require './db/seeds/users'
 require './db/seeds/posts'
+require './db/seeds/notification_timings'

--- a/db/seeds/environment/development.rb
+++ b/db/seeds/environment/development.rb
@@ -1,0 +1,3 @@
+require './db/seeds/users'
+require './db/seeds/posts'
+require './db/seeds/notification_timings'

--- a/db/seeds/environment/test.rb
+++ b/db/seeds/environment/test.rb
@@ -1,0 +1,2 @@
+# マスターデータなので
+require './db/seeds/notification_timings'

--- a/db/seeds/notification_timings.rb
+++ b/db/seeds/notification_timings.rb
@@ -1,0 +1,4 @@
+puts 'Start inserting seed "notification_timings" ...'
+NotificationTiming.find_or_create_by!(timing_type: :on_commented)
+NotificationTiming.find_or_create_by!(timing_type: :on_liked)
+NotificationTiming.find_or_create_by!(timing_type: :on_followed)

--- a/spec/factories/notification_timings.rb
+++ b/spec/factories/notification_timings.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: notification_timings
+#
+#  id          :bigint           not null, primary key
+#  timing_type :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_notification_timings_on_timing_type  (timing_type) UNIQUE
+#
+FactoryBot.define do
+  factory :notification_timing do
+    timing_type { 1 }
+  end
+end

--- a/spec/factories/user_notification_timings.rb
+++ b/spec/factories/user_notification_timings.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: user_notification_timings
+#
+#  id                     :bigint           not null, primary key
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  notification_timing_id :bigint           not null
+#  user_id                :bigint           not null
+#
+# Indexes
+#
+#  idx_user_n_timings_on_user_id_and_n_timing_id              (user_id,notification_timing_id) UNIQUE
+#  index_user_notification_timings_on_notification_timing_id  (notification_timing_id)
+#  index_user_notification_timings_on_user_id                 (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (notification_timing_id => notification_timings.id)
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :user_notification_timing do
+    user { nil }
+    notification_timing { nil }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -117,4 +117,46 @@ RSpec.describe User, type: :model do
     it { is_expected.to include post_by_user_b }
     it { is_expected.not_to include post_by_user_c }
   end
+
+  describe '#accepted_notification?' do
+    let!(:user) { create(:user) }
+    describe ':on_commented' do
+      before do
+        notification_timing = NotificationTiming.find_by!(timing_type: :on_commented)
+        user.notification_timings << notification_timing
+      end
+
+      it 'コメント時の通知のみ許可されていること' do
+        expect(user.accepted_notification?(:on_commented)).to eq true
+        expect(user.accepted_notification?(:on_liked)).to eq false
+        expect(user.accepted_notification?(:on_followed)).to eq false
+      end
+    end
+
+    describe ':on_liked' do
+      before do
+        notification_timing = NotificationTiming.find_by!(timing_type: :on_liked)
+        user.notification_timings << notification_timing
+      end
+
+      it 'いいね時の通知のみ許可されていること' do
+        expect(user.accepted_notification?(:on_commented)).to eq false
+        expect(user.accepted_notification?(:on_liked)).to eq true
+        expect(user.accepted_notification?(:on_followed)).to eq false
+      end
+    end
+
+    describe ':on_followed' do
+      before do
+        notification_timing = NotificationTiming.find_by!(timing_type: :on_followed)
+        user.notification_timings << notification_timing
+      end
+
+      it 'フォロー時の通知のみ許可されていること' do
+        expect(user.accepted_notification?(:on_commented)).to eq false
+        expect(user.accepted_notification?(:on_liked)).to eq false
+        expect(user.accepted_notification?(:on_followed)).to eq true
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,5 +62,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.before :suite do
+    system 'bin/rails db:seed'
+  end
+
   config.include LoginMacros
 end


### PR DESCRIPTION
## 概要

メール通知のオンオフを切り替えられる機能を実装しました。
[![Image from Gyazo](https://i.gyazo.com/0f7bcb111752d538688bbbbc1a7524e6.gif)](https://gyazo.com/0f7bcb111752d538688bbbbc1a7524e6)

- `enum_help`gemを導入して、enumの国際化をしています

### エンドポイント

| やりたいこと | HTTPメソッド | エンドポイント | コントローラ＃アクション |
|--------|-------|--------|-------|
| 通知の設定画面を表示 | GET | /mypage/notification_setting/edit | mypage/notification_settings#edit |
| 通知の設定を変更 | PATCH | /mypage/notification_setting | mypage/notification_settings#update |

## 確認方法

1. Gem を追加したので `bundle install` を実行してください
2. スキーマを変更しているので `bin/rails db:migrate` を実行してください
3. 通知設定項目を初期データとして投入しているので`bin/rails db:seed`を実行してください

`mypage/notification_setting/edit`から通知のオンオフを切り替えられることを確認してください。

## チェックリスト

- [x] テストを書いた
- [x] Lint のチェックをパスした

## コメント

その他気になる部分があればここに書いてレビュワーに伝えましょう